### PR TITLE
I'd like to use the `:not` selector for input types instead of declaring all of them

### DIFF
--- a/component/_forms.scss
+++ b/component/_forms.scss
@@ -15,8 +15,8 @@ fieldset {
 
 label {}
 
-input:not(type="checkbox"),
-input:not(type="radio") {
+input:not([type='checkbox']),
+input:not([type='radio']) {
 	border: $form-input-border-width solid $form-input-border-color;
 	border-radius: $form-input-border-radius;
 	color: $form-input-color;

--- a/component/_forms.scss
+++ b/component/_forms.scss
@@ -15,7 +15,8 @@ fieldset {
 
 label {}
 
-#{$all-text-inputs} {
+input:not(type="checkbox"),
+input:not(type="radio") {
 	border: $form-input-border-width solid $form-input-border-color;
 	border-radius: $form-input-border-radius;
 	color: $form-input-color;
@@ -25,10 +26,10 @@ label {}
 	@include placeholder {
 		color: $form-input-color;
 	}
-}
 
-#{$all-text-inputs-focus} {
-	color: $form-input-color;
+	&:focus {
+		color: $form-input-color;
+	}
 }
 
 textarea {

--- a/component/_forms.scss
+++ b/component/_forms.scss
@@ -17,6 +17,7 @@ label {}
 
 input:not([type='checkbox']),
 input:not([type='radio']) {
+	@include transition( all 250ms ease );
 	border: $form-input-border-width solid $form-input-border-color;
 	border-radius: $form-input-border-radius;
 	color: $form-input-color;


### PR DESCRIPTION
When they are all specifically declared, it makes it difficult to override them later in specific instances. And the `:not` selector is well supported now >IE9
