### PR TITLE
Use #{$all-text-inputs} selector instead of ineffective OR of NOTs

### DIFF
--- a/component/_forms.scss
+++ b/component/_forms.scss
@@ -17,8 +17,7 @@ fieldset {
 
 label {}
 
-input:not([type='checkbox']),
-input:not([type='radio']) {
+#{$all-text-inputs} {
 	@include transition( all 250ms ease );
 	border: $form-input-border-width solid $form-input-border-color;
 	border-radius: $form-input-border-radius;


### PR DESCRIPTION
These selectors:

```
input:not([type='checkbox']),
input:not([type='radio']) {
```

Are equivalent to:

```
input {
```

Since when you take the union of two negations, it's the full set. Logic.

Use `#{$all-text-inputs}` selector instead (from Bourbon) to reference all text-type inputs.
