### PR TITLE
17 modernizr update

### DIFF
--- a/base/_mixins.scss
+++ b/base/_mixins.scss
@@ -2,45 +2,105 @@
 
 // @link http://csswizardry.com/2016/02/mixins-better-for-performance/
 
-// Provide a hover effect for non-touch devices, turn it into an Active state for mobile, and maintain a fallback.
+// Provide an accesible hover for non-touch devices, turns it into the active state for mobile, and maintain a no-js fallback
 // @requires Modernizr as a JS dependency to get .no-touch classes
 // Adds styles via @content
 // @jhogue
+
+// Usage: 
+// .link {
+//   padding: .5em 1em; // Styles that do not change when interacting with this element
+// 
+//   @include touch-hover('idle') {
+//     color: black;
+//   }
+//   @include touch-hover('hover') {
+//     color: red;
+//   }
+//   
+//   &__disabled {
+//     @include touch-hover('hover', true) {
+//      color: silver;
+//     }
+//   }
+// }
+
+// Outputs: 
+// .link {
+//   padding: .5em 1em;
+// }
+// .link, .link:link, .link:visited {
+//   color: black;
+// }
+// .no-js .link:hover, .no-js .link:focus, .js.no-touchevents .link:hover, .js.no-touchevents .link:focus, .js.touchevents .link:active {
+//   color: red;
+// }
+// .no-js .link__disabled, .no-js .link__disabled:link, .no-js .link__disabled:visited, .no-js .link__disabled:hover, .no-js .link__disabled:focus, .js.no-touchevents .link__disabled, .js.no-touchevents .link__disabled:link, .js.no-touchevents .link__disabled:visited, .js.no-touchevents .link__disabled:hover, .js.no-touchevents .link__disabled:focus, .js.touchevents .link__disabled, .js.touchevents .link__disabled:active {
+//   cursor: default;
+//   color: silver;
+// }
 //
 @mixin touch-hover( $state: 'idle', $disabled: false ) {
-	// Change these as needed, based on your version of Modernizr
 	$modernizr-hook-off: 'no-touchevents';
 	$modernizr-hook-on: 'touchevents';
+  $modernizr: true !default; // set this to false to maintain mixin but use the no-modernizr fallbacks
 
 	@if $state == 'idle' {
 		&,
 		&:link,
 		&:visited {
-	    @content;
+		  @content;
 		}
-	} 
+	}
 
 	@if $state == 'hover' {
-		@if $disabled {
-			.no-js &,
-			.no-js &:hover, // the fallback
-			.no-js &:focus,
-			.js.#{$modernizr-hook-off} &,
-			.js.#{$modernizr-hook-off} &:hover, // enhanced for no-touch
-			.js.#{$modernizr-hook-off} &:focus,
-			.js.#{$modernizr-hook-on} &,
-			.js.#{$modernizr-hook-on} &:active { // relay same styles to active for touch devices
-				@content;
-			}
-		} @else {
-			.no-js &:hover, // the fallback
-			.no-js &:focus,
-			.js.#{$modernizr-hook-off} &:hover, // enhanced for no-touch
-			.js.#{$modernizr-hook-off} &:focus,
-			.js.#{$modernizr-hook-on} &:active { // relay same styles to active for touch devices
-				@content;
-			}
-		}
+		@if $disabled == true {
+  		// If this link is meant to look disabled, style all states the same
+  		@if $modernizr == true {
+    		.no-js &,
+    		.no-js &:link,
+    		.no-js &:visited,
+  			.no-js &:hover,
+  			.no-js &:focus,
+  			.js.#{$modernizr-hook-off} &,
+  			.js.#{$modernizr-hook-off} &:link,
+  			.js.#{$modernizr-hook-off} &:visited,
+  			.js.#{$modernizr-hook-off} &:hover,
+  			.js.#{$modernizr-hook-off} &:focus,
+  			.js.#{$modernizr-hook-on} &,
+  			.js.#{$modernizr-hook-on} &:active {
+  				cursor: default;
+  				@content;
+  			}
+      } @else {
+        &,
+        &:link,
+        &:visited,
+  			&:hover,
+  			&:focus,
+  			&:active {
+    			cursor: default;
+    			@content;
+  			}
+      }
+    } @else {
+  		@if $modernizr == true {
+    		.no-js &:hover,
+  			.no-js &:focus,
+  			.js.#{$modernizr-hook-off} &:hover,
+  			.js.#{$modernizr-hook-off} &:focus,
+  			.js.#{$modernizr-hook-on} &:active {
+  				@content;
+  			}
+      } @else {
+        &,
+  			&:hover,
+  			&:focus,
+  			&:active {
+    			@content;
+  			}
+      }
+    }
 	}
 }
 

--- a/base/_mixins.scss
+++ b/base/_mixins.scss
@@ -93,7 +93,6 @@
           @content;
         }
       } @else {
-        &,
         &:hover,
         &:focus,
         &:active {

--- a/base/_mixins.scss
+++ b/base/_mixins.scss
@@ -41,67 +41,67 @@
 // }
 //
 @mixin touch-hover( $state: 'idle', $disabled: false ) {
-	$modernizr-hook-off: 'no-touchevents';
-	$modernizr-hook-on: 'touchevents';
+  $modernizr-hook-off: 'no-touchevents';
+  $modernizr-hook-on: 'touchevents';
   $modernizr: true !default; // set this to false to maintain mixin but use the no-modernizr fallbacks
 
-	@if $state == 'idle' {
-		&,
-		&:link,
-		&:visited {
-		  @content;
-		}
-	}
+@if $state == 'idle' {
+  &,
+  &:link,
+  &:visited {
+    @content;
+  }
+}
 
-	@if $state == 'hover' {
-		@if $disabled == true {
-  		// If this link is meant to look disabled, style all states the same
-  		@if $modernizr == true {
-    		.no-js &,
-    		.no-js &:link,
-    		.no-js &:visited,
-  			.no-js &:hover,
-  			.no-js &:focus,
-  			.js.#{$modernizr-hook-off} &,
-  			.js.#{$modernizr-hook-off} &:link,
-  			.js.#{$modernizr-hook-off} &:visited,
-  			.js.#{$modernizr-hook-off} &:hover,
-  			.js.#{$modernizr-hook-off} &:focus,
-  			.js.#{$modernizr-hook-on} &,
-  			.js.#{$modernizr-hook-on} &:active {
-  				cursor: default;
-  				@content;
-  			}
+  @if $state == 'hover' {
+    @if $disabled == true {
+      // If this link is meant to look disabled, style all states the same
+      @if $modernizr == true {
+        .no-js &,
+        .no-js &:link,
+        .no-js &:visited,
+        .no-js &:hover,
+        .no-js &:focus,
+        .js.#{$modernizr-hook-off} &,
+        .js.#{$modernizr-hook-off} &:link,
+        .js.#{$modernizr-hook-off} &:visited,
+        .js.#{$modernizr-hook-off} &:hover,
+        .js.#{$modernizr-hook-off} &:focus,
+        .js.#{$modernizr-hook-on} &,
+        .js.#{$modernizr-hook-on} &:active {
+          cursor: default;
+          @content;
+        }
       } @else {
         &,
         &:link,
         &:visited,
-  			&:hover,
-  			&:focus,
-  			&:active {
-    			cursor: default;
-    			@content;
-  			}
+        &:hover,
+        &:focus,
+        &:active {
+          cursor: default;
+          @content;
+        }
       }
     } @else {
-  		@if $modernizr == true {
-    		.no-js &:hover,
-  			.no-js &:focus,
-  			.js.#{$modernizr-hook-off} &:hover,
-  			.js.#{$modernizr-hook-off} &:focus,
-  			.js.#{$modernizr-hook-on} &:active {
-  				@content;
-  			}
+      @if $modernizr == true {
+        .no-js &:hover,
+        .no-js &:focus,
+        .js.#{$modernizr-hook-off} &:hover,
+        .js.#{$modernizr-hook-off} &:focus,
+        .js.#{$modernizr-hook-on} &:active {
+          @content;
+        }
       } @else {
         &,
-  			&:hover,
-  			&:focus,
-  			&:active {
-    			@content;
-  			}
+        &:hover,
+        &:focus,
+        &:active {
+          @content;
+        }
       }
     }
-	}
+  }
 }
 
 // Column Grid

--- a/base/_mixins.scss
+++ b/base/_mixins.scss
@@ -7,28 +7,39 @@
 // Adds styles via @content
 // @jhogue
 //
-@mixin touch-hover( $disabled: false ) {
-	$modernizr-hook-off: 'no-touch';
-	$modernizr-hook-on: 'touch';
+@mixin touch-hover( $state: 'idle', $disabled: false ) {
+	// Change these as needed, based on your version of Modernizr
+	$modernizr-hook-off: 'no-touchevents';
+	$modernizr-hook-on: 'touchevents';
 
-	@if $disabled {
-		.no-js &,
-		.no-js &:hover, // the fallback
-		.no-js &:focus,
-		.js.#{$modernizr-hook-off} &,
-		.js.#{$modernizr-hook-off} &:hover, // enhanced for no-touch
-		.js.#{$modernizr-hook-off} &:focus,
-		.js.#{$modernizr-hook-on} &,
-		.js.#{$modernizr-hook-on} &:active { // relay same styles to active for touch devices
-			@content;
+	@if $state == 'idle' {
+		&,
+		&:link,
+		&:visited {
+	    @content;
 		}
-	} @else {
-		.no-js &:hover, // the fallback
-		.no-js &:focus,
-		.js.#{$modernizr-hook-off} &:hover, // enhanced for no-touch
-		.js.#{$modernizr-hook-off} &:focus,
-		.js.#{$modernizr-hook-on} &:active { // relay same styles to active for touch devices
-			@content;
+	} 
+
+	@if $state == 'hover' {
+		@if $disabled {
+			.no-js &,
+			.no-js &:hover, // the fallback
+			.no-js &:focus,
+			.js.#{$modernizr-hook-off} &,
+			.js.#{$modernizr-hook-off} &:hover, // enhanced for no-touch
+			.js.#{$modernizr-hook-off} &:focus,
+			.js.#{$modernizr-hook-on} &,
+			.js.#{$modernizr-hook-on} &:active { // relay same styles to active for touch devices
+				@content;
+			}
+		} @else {
+			.no-js &:hover, // the fallback
+			.no-js &:focus,
+			.js.#{$modernizr-hook-off} &:hover, // enhanced for no-touch
+			.js.#{$modernizr-hook-off} &:focus,
+			.js.#{$modernizr-hook-on} &:active { // relay same styles to active for touch devices
+				@content;
+			}
 		}
 	}
 }
@@ -80,15 +91,15 @@
   @if length($ratio) < 2 or length($ratio) > 2 {
     @warn "$ratio must be a list with two values.";
   }
-  width: 100%;
   height: 0;
   padding-bottom: percentage(nth($ratio, 2) / nth($ratio, 1));
+  width: 100%;
 }
 
 // Apply as a typical container mixin
 @mixin proportional-container( $ratio: 1 1 ) {
-  position: relative;
   overflow: hidden;
+  position: relative;
   z-index: 1;
   @include maintain-ratio( $ratio );
 }
@@ -118,8 +129,8 @@
     // Default: Fill the height, let the width be what it needs to be
     @include transform( translateX(-50%) );
     top: 0; left: 50%;
-    max-width: 200%; // reset the max-width: 100% present on all img elements
     height: 100%;
+    max-width: 200%; // reset the max-width: 100% present on all img elements
     width: auto;
   }
 }

--- a/base/_typesizes.scss
+++ b/base/_typesizes.scss
@@ -63,6 +63,18 @@ $type-sizes: (
 // ! ===== Mixins to support pulling out type sizes at breakpoints =====
 
 //
+// Deep getter to go into the $type-sizes array
+// and return with a specific element at a particular breakpoint
+// @jhogue
+//
+// @usage: .bravo { font-size: type-size(h2,large); }
+// @returns: .bravo { font-size: 1.5rem; }
+//
+@function type-size($break, $element: 'base') {
+  @return map-get( map-get($type-sizes, $break), $element );
+}
+
+//
 // A deep function used by other mixins
 // Check each $key-s by name and treats some of them special
 // @jhogue
@@ -93,6 +105,14 @@ $type-sizes: (
 // usage: @include all-type-sizes( $array-key );
 // @jhogue
 //
+// @usage: @media (min-width: bp(medium) ) { @include all-type-sizes(medium); }
+// @returns: @media (min-width: 60em) {
+//	h1 { font-size: 1.6875rem; }
+//	h2 { font-size: 1.5rem; }
+//	h3 { font-size: 1.3125rem; }
+//	h4 { font-size: 1.1875rem; }
+//	p { font-size: 1.0625rem; }
+//
 @mixin all-type-sizes($array: 'base') {
 	@each $item, $value in map-get($type-sizes, $array) {
 		@include type-size-key-value-output($item, $value);
@@ -103,6 +123,15 @@ $type-sizes: (
 // Iterates over the list of breakpoints and returns only one element at ALL sizes
 // usage: @include one-element-size( $element );
 // @jhogue
+//
+// @usage: alpha { @include one-element-size(h1); }
+// @returns: alpha { font-size: 1.5rem; }
+//    @media (min-width: 61.25em) {
+//		  .alpha { font-size: 1.6875rem; }
+//	  }
+//    @media (min-width: 75em) {
+//   	  .alpha { font-size: 2.25rem; }
+//    }
 //
 @mixin one-element-size($elem: 'base') {
 	// First, loop over the breakpoints
@@ -126,50 +155,3 @@ $type-sizes: (
 		}
 	}
 }
-
-
-// ! ===== Examples =====
-// ! @mixin all-type-sizes() – Output all elements for one breakpoint
-//	@media (min-width: bp(medium) ) {
-//		@include all-type-sizes(medium);
-//	}
-//
-// Outputs:
-// @media (min-width: 60em) {
-//	h1 {
-//		font-size: 1.6875rem;
-//	}
-//	h2 {
-//		font-size: 1.5rem;
-//	}
-//	h3 {
-//		font-size: 1.3125rem;
-//	}
-//	h4 {
-//		font-size: 1.1875rem;
-//	}
-//	p {
-//		font-size: 1.0625rem;
-//	}
-//}
-//
-// ! @mixin one-element-size() – Output one specific element for all breakpoints
-//	alpha { @include one-element-size(h1); }
-//
-// Outputs:
-//	alpha { font-size: 1.5rem; }
-//
-//	@media (min-width: 61.25em) {
-//		.alpha { font-size: 1.6875rem; }
-//	}
-//
-// @media (min-width: 75em) {
-// 	.alpha { font-size: 2.25rem; }
-// }
-//
-//
-// ! @function rwd-size() — Output one size for one element
-//	.bravo { font-size: rem( rwd-size(h2,large) ); }
-//
-// Outputs:
-//	.bravo { font-size: 1.5rem; }

--- a/base/_typesizes.scss
+++ b/base/_typesizes.scss
@@ -67,11 +67,12 @@ $type-sizes: (
 // and return with a specific element at a particular breakpoint
 // @jhogue
 //
-// @usage: .bravo { font-size: type-size(h2,large); }
-// @returns: .bravo { font-size: 1.5rem; }
+// @usage: .bravo { @include one-type-size(large, h2); }
+// @returns: .bravo { font-size: 0.66667rem; }
 //
-@function type-size($break, $element: 'base') {
-  @return map-get( map-get($type-sizes, $break), $element );
+@mixin one-type-size($break, $element: 'base') {
+  $elementsize: map-get( map-get($type-sizes, $break), $element );
+  font-size: rem-fontsize($elementsize);
 }
 
 //

--- a/base/_typesizes.scss
+++ b/base/_typesizes.scss
@@ -113,7 +113,7 @@ $type-sizes: (
 //	h3 { font-size: 1.3125rem; }
 //	h4 { font-size: 1.1875rem; }
 //	p { font-size: 1.0625rem; }
-//
+// }
 @mixin all-type-sizes($array: 'base') {
 	@each $item, $value in map-get($type-sizes, $array) {
 		@include type-size-key-value-output($item, $value);


### PR DESCRIPTION
Relates to Issue #17 

Add our most recent version of the touch-hover mixin to the scaffold. Includes a set of variables for the Modernizr hook. Authors can change the hook in one place if they are using a newer version of modernize. 

Old Modernizr: `no-touch / touch`
New Modernizr: `no-touchevents / touchevents`
