### PR TITLE
Inputs and selects not inheriting `border-box` from the HTML declaration

### DIFF
--- a/component/_forms.scss
+++ b/component/_forms.scss
@@ -20,6 +20,7 @@ label {}
 #{$all-text-inputs} {
 	@include transition( all 250ms ease );
 	border: $form-input-border-width solid $form-input-border-color;
+	box-sizing: border-box; // Declare explicitly, as form elements do not inherit from HTML declaration in iOS and Android
 	border-radius: $form-input-border-radius;
 	color: $form-input-color;
 	padding: $form-input-padding;


### PR DESCRIPTION
Issue #26 

`border-box` is declared via Neat on the HTML element globally. But, iOS and Android do not seem to adhere to that inheritance. Therefore, we declare it again specifically on form elements. 
