### PR TITLE
Remove named palette in typography

### DIFF
--- a/base/_colors.scss
+++ b/base/_colors.scss
@@ -73,6 +73,7 @@ $palettes: (
 $color-text: palette(mono);
 $color-link: palette(brand);
 $color-hover: palette(brand, dark);
+$color-code: palette(brand, green);
 $color-body: palette(mono, 90);
 $color-background: palette(mono, white);
 $color-header: palette(mono, 10);

--- a/base/_colors.scss
+++ b/base/_colors.scss
@@ -37,6 +37,7 @@ $palettes: (
 		base: #888,
 		33: #999,
 		25: #ccc,
+		15: #e6e6e6,
 		10: #f2f2f2,
 		white: #fff
 	),
@@ -74,6 +75,7 @@ $color-text: palette(mono);
 $color-link: palette(brand);
 $color-hover: palette(brand, dark);
 $color-code: palette(brand, green);
+$color-error: palette(brand);
 $color-body: palette(mono, 90);
 $color-background: palette(mono, white);
 $color-header: palette(mono, 10);

--- a/base/_typography.scss
+++ b/base/_typography.scss
@@ -13,7 +13,7 @@ button,
 input,
 select,
 textarea {
-  color: palette(mono);
+  color: $color-text;
   font-family: $font-sans;
   font-weight: $font-weight-normal;
   line-height: $line-height;
@@ -23,12 +23,12 @@ a {
   @include transition(all 250ms ease);
 
   @include touch-hover('idle') {
-    color: palette(mono, 75);
+    color: $color-link;
     text-decoration: none;
   }
 
   @include touch-hover('hover') {
-    color: palette(brand);
+    color: $color-hover;
     text-decoration: none;
   }
 
@@ -126,48 +126,48 @@ table {
 
 // Block level elements
 blockquote {
-	position: relative;
+  position: relative;
 
-	p {
-		color: palette(mono);
-		font-style: italic;
-		padding-left: em(32);
-	}
+  p {
+    color: palette(mono);
+    font-style: italic;
+    padding-left: em(32);
+  }
 
-	p::before,
-	p:last-child::after {
-		color: palette(brand);
-		font-family: $font-serif;
-		font-size: rem(48);
-		font-style: italic;
-		font-weight: $font-weight-bold;
-		line-height: 1;
-	}
+  p::before,
+  p:last-child::after {
+    color: palette(brand);
+    font-family: $font-serif;
+    font-size: rem(48);
+    font-style: italic;
+    font-weight: $font-weight-bold;
+    line-height: 1;
+  }
 
-	p::before {
-		content: "“";
-		position: absolute;
-			top: 0; left: .0625em;
-	}
+  p::before {
+    content: "“";
+    position: absolute;
+      top: 0; left: .0625em;
+  }
 
-	p:last-child::after {
-		content: "”";
-		display: inline;
-		line-height: 0;
-		margin-left: .125em;
-		vertical-align: text-bottom;
-	}
+  p:last-child::after {
+    content: "”";
+    display: inline;
+    line-height: 0;
+    margin-left: .125em;
+    vertical-align: text-bottom;
+  }
 }
 
 address { font-style: italic; }
 
 hr {
-	border: none;
-	border-top: 1px solid palette(mono, 25);
-	height: 0;
-	line-height: 1;
-	margin: $vert-line-height 0;
-	width: 100%;
+  border: none;
+  border-top: 1px solid palette(mono, 25);
+  height: 0;
+  line-height: 1;
+  margin: $vert-line-height 0;
+  width: 100%;
 }
 
 ul,
@@ -195,14 +195,14 @@ dl { border-top: 1px solid $color-borders; }
 
 dt,
 dd {
-	border-left: 1px solid $color-borders;
-	border-right: 1px solid $color-borders;
-	padding: .75em 1em .5625em;
+  border-left: 1px solid $color-borders;
+  border-right: 1px solid $color-borders;
+  padding: .75em 1em .5625em;
 }
 
 dt {
-	border-bottom: 1px solid $color-borders;
-	font-weight: $font-weight-bold;
+  border-bottom: 1px solid $color-borders;
+  font-weight: $font-weight-bold;
 }
 
 dd { border-bottom: 2px solid $color-borders; }
@@ -210,35 +210,35 @@ dd { border-bottom: 2px solid $color-borders; }
 figure { margin: 0; }
 
 table {
-	@if $table-border-collapse == true {
-		border-collapse: collapse;
-	}
-	border-spacing: 0;
-	width: 100%;
+  @if $table-border-collapse == true {
+    border-collapse: collapse;
+  }
+  border-spacing: 0;
+  width: 100%;
 
-	th {
-		border-bottom: 2px solid $table-border-color;
-		font-weight: $font-weight-bold;
-		padding: $table-cell-padding;
-		text-align: left;
-	}
+  th {
+    border-bottom: 2px solid $table-border-color;
+    font-weight: $font-weight-bold;
+    padding: $table-cell-padding;
+    text-align: left;
+  }
 
-	td {
-		border-top: 1px solid $table-border-color;
-		padding: $table-cell-padding;
-	}
+  td {
+    border-top: 1px solid $table-border-color;
+    padding: $table-cell-padding;
+  }
 
-	caption {
-		text-align: center;
-	}
+  caption {
+    text-align: center;
+  }
 
-	// zebra striping pattern
-	tbody {
+  // zebra striping pattern
+  tbody {
 
-		tr:nth-of-type(odd) {
-			background-color: $table-border-color;
-		}
-	}
+    tr:nth-of-type(odd) {
+      background-color: $table-border-color;
+    }
+  }
 }
 
 // Inline typography elements
@@ -253,9 +253,9 @@ sup { letter-spacing: .03125em; }
 
 sub,
 sup {
-	font-size: 75%;
-	line-height: 1;
-	position: relative;
+  font-size: 75%;
+  line-height: 1;
+  position: relative;
 }
 
 sup { top: -0.5em; }
@@ -264,16 +264,16 @@ sub { bottom: -0.25em; }
 
 abbr[title],
 cite,
-dfn[title] { border-bottom: 1px dotted palette(brand); }
+dfn[title] { border-bottom: 1px dotted $color-link; }
 
 abbr[title],
 dfn[title] { cursor: help; }
 
 abbr[title] {
-	font-size: 75%;
-	font-weight: $font-weight-bold;
-	letter-spacing: 0.125em;
-	text-transform: uppercase;
+  font-size: 75%;
+  font-weight: $font-weight-bold;
+  letter-spacing: 0.125em;
+  text-transform: uppercase;
 }
 
 b,
@@ -284,25 +284,25 @@ em,
 cite { font-style: italic; }
 
 var {
-	color: palette(mono, 75);
-	display: inline-block;
-	font-style: italic;
-	padding: 0 .125em;
+  color: palette(mono, 75);
+  display: inline-block;
+  font-style: italic;
+  padding: 0 .125em;
 }
 
 // Proper code blocks need to be surrounded by a <pre>. They work together.
 pre {
-	white-space: pre-wrap;
-	word-wrap: break-word; // For IE 5.5+ and up
+  white-space: pre-wrap;
+  word-wrap: break-word; // For IE 5.5+ and up
 
-	code {
-		border-bottom: 1px solid palette(mono, 25);
-		border-left: 5px solid $color-code;
-		border-radius: 0;
-		display: block;
-		margin: 0;
-		padding: 1.375em 1.25em 1.3125em;
-	}
+  code {
+    border-bottom: 1px solid palette(mono, 25);
+    border-left: 5px solid $color-code;
+    border-radius: 0;
+    display: block;
+    margin: 0;
+    padding: 1.375em 1.25em 1.3125em;
+  }
 }
 
 code,
@@ -310,24 +310,24 @@ kbd,
 samp,
 mark,
 ins {
-	display: inline-block;
-	line-height: 1.5;
-	padding: .125em .25em 0;
+  display: inline-block;
+  line-height: 1.5;
+  padding: .125em .25em 0;
 }
 
 code,
 kbd,
 samp {
-	// scss-lint:disable DuplicateProperty
-	background: palette(mono, 10);
-	background: rgba(#000, .05);
-	border-radius: $default-border-radius;
-	box-shadow: 0 0 .25em rgba(#000, .1) inset;
-	font-family: $font-mono;
+  // scss-lint:disable DuplicateProperty
+  background: palette(mono, 10);
+  background: rgba(#000, .05);
+  border-radius: $default-border-radius;
+  box-shadow: 0 0 .25em rgba(#000, .1) inset;
+  font-family: $font-mono;
 }
 
 code {
-	color: $color-code;
+  color: $color-code;
 }
 
 mark { background-color: #ff9; }
@@ -335,13 +335,13 @@ mark { background-color: #ff9; }
 strike,
 s { color: palette(mono, 25); }
 
-del { color: palette(brand); }
+del { color: $color-error; }
 
 u { text-decoration: underline; }
 
 ins {
-	background-color: palette(mono, 25);
-	text-decoration: none;
+  background-color: palette(mono, 25);
+  text-decoration: none;
 }
 
 small { font-size: 87.5%; }
@@ -349,53 +349,53 @@ small { font-size: 87.5%; }
 // These should change depending on the language
 [lang="en-US"] {
 
-	q {
-		display: inline;
+  q {
+    display: inline;
 
-		::before { content: "“"; }
+    ::before { content: "“"; }
 
-		::after {
-			content: "”";
-			white-space: nowrap;
-		}
+    ::after {
+      content: "”";
+      white-space: nowrap;
+    }
 
-		// Nested
-		q::before { content: "‘"; }
+    // Nested
+    q::before { content: "‘"; }
 
-		q::after { content: "’"; }
-	}
+    q::after { content: "’"; }
+  }
 }
 
 .typography {
 
-	// For the style guide template
-	.example {
-		background-color: transparent;
-		border: 1px solid $color-borders;
-		box-shadow: 0 0 1em rgba(#000, 0.2 );
-		margin: -1em -1.25em -1px;
-		padding: 1em 1.25em 1px;
-		position: relative;
-	}
+  // For the style guide template
+  .example {
+    background-color: transparent;
+    border: 1px solid $color-borders;
+    box-shadow: 0 0 1em rgba(#000, 0.2);
+    margin: -1em -1.25em -1px;
+    padding: 1em 1.25em 1px;
+    position: relative;
+  }
 
-	.example::before {
-		background-color: palette(brand);
-		color: #fff;
-		content: 'EXAMPLE';
-		font-size: .75em;
-		padding: .4em .75em .3em;
-		position: absolute;
-			top: 0; right: 0;
-		z-index: 9999;
-	}
-	//.example + .examplecode { margin-top: -1.25em; }
-	.element-caption { display: block; }
+  .example::before {
+    background-color: palette(brand);
+    color: #fff;
+    content: 'EXAMPLE';
+    font-size: .75em;
+    padding: .4em .75em .3em;
+    position: absolute;
+      top: 0; right: 0;
+    z-index: 9999;
+  }
+  //.example + .examplecode { margin-top: -1.25em; }
+  .element-caption { display: block; }
 }
 
 .vertical-grid {
-	// Debug vertical rhythm
-	// scss-lint:disable UrlFormat
-	background-image: url('http://basehold.it/i/31/cc0000');
-	background-position: 0 14px;
-	// scss-lint:enable UrlFormat
+  // Debug vertical rhythm
+  // scss-lint:disable UrlFormat
+  background-image: url('http://basehold.it/i/31/cc0000');
+  background-position: 0 14px;
+  // scss-lint:enable UrlFormat
 }

--- a/base/_typography.scss
+++ b/base/_typography.scss
@@ -297,7 +297,7 @@ pre {
 
 	code {
 		border-bottom: 1px solid palette(mono, 25);
-		border-left: 5px solid palette(brand, green);
+		border-left: 5px solid $color-code;
 		border-radius: 0;
 		display: block;
 		margin: 0;
@@ -327,7 +327,7 @@ samp {
 }
 
 code {
-	color: palette(brand, green);
+	color: $color-code;
 }
 
 mark { background-color: #ff9; }

--- a/component/_forms.scss
+++ b/component/_forms.scss
@@ -47,8 +47,8 @@ textarea {
   &[required]:focus,
   &[required=true]:focus,
   &[required="required"]:focus {
-    border-color: palette(brand);
-    box-shadow: 0 0 .5em rgba( palette(brand), .5 );
+    border-color: $color-error;
+    box-shadow: 0 0 .5em rgba( $color-error, .5 );
     outline: none;
   }
 }


### PR DESCRIPTION
We had places where the palette was being used, but typically, the palette is the first thing that we change and then SASS will not compile because we have calls to colors that no longer exist. 

Instead, I turned those use cases into variables. Now if someone completely updates the colors.scss file, we should not have compile errors elsewhere. 

Closes #14 