### PR TITLE
Fix Shorthand Property

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -167,7 +167,7 @@ linters:
 
   Shorthand:
     enabled: true
-    allowed_shorthands: [1, 2, 3]
+    allowed_shorthands: [1, 2, 3, 4]
 
   SingleLinePerProperty:
     enabled: true


### PR DESCRIPTION
Linter was throwing errors on declarations containing 4 properties. ex. `padding: 1rem 2rem 1rem 1.5rem;`