### PR TITLE
Revisit the Reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Oomph's scss-scaffold
 
-This is Oomph's boilerplate scaffold for starting front-end theme development.
+This is Oomph's boilerplate scaffold for starting front-end theme development. 
+The basics of typography are here, along with some helpers that we find useful to 
+include on every project. [A sample of what these naked styles render as can be 
+found here](http://jhogue.dev.oomphcloud.com/scaffold/sample.html).
 
 ## Documentation
 
@@ -60,7 +63,7 @@ For more information on tags, check https://git-scm.com/book/en/v2/Git-Basics-Ta
 When adding scaffold to a new project, make sure you use the latest tagged release 
 instead of just cloning master (as we did previously).
 
-To grab the lastest tagged release, navigate to the [Releases section](https://github.com/oomphinc/scss-scaffold/releases) 
+To grab the latest tagged release, navigate to the [Releases section](https://github.com/oomphinc/scss-scaffold/releases) 
 and download the most recent version.
 
 ### Add Bourbon & Neat

--- a/abstracts/oomph-mixins/_buttons.scss
+++ b/abstracts/oomph-mixins/_buttons.scss
@@ -47,13 +47,13 @@
   @if $type == 'secondary' {
 
     @include touch-hover('idle') {
-      background-color: palette(mono, 90);
-      border-color: palette(mono, black);
-      color: palette(mono, 25);
+      background-color: palette(mono, 25);
+      border-color: palette(mono, 33);
+      color: palette(mono, 90);
     }
 
     @include touch-hover('hover') {
-      background-color: palette(mono, black);
+      background-color: palette(mono);
       color: palette(mono, white);
     }
   }

--- a/abstracts/oomph-mixins/_fluid-typography.scss
+++ b/abstracts/oomph-mixins/_fluid-typography.scss
@@ -75,8 +75,8 @@
 
   // Change these key values into a typographic value
   // by getting the matching key/value pair from the $type-sizes array
-  $min-value: em(one-type-size($first-key, $elem));
-  $max-value: em(one-type-size($last-key, $elem));
+  $min-value: rem(one-type-size($first-key, $elem));
+  $max-value: rem(one-type-size($last-key, $elem));
 
   // Use the same keys to grab the corresponding breakpoints
   @if type-of($breakpoints) != 'map' {

--- a/base/_forms.scss
+++ b/base/_forms.scss
@@ -6,22 +6,24 @@ $form-input-border-width: 1px;
 $form-input-border-radius: $default-border-radius;
 $form-input-placeholder-color: palette(mono, 33);
 $form-input-color: palette(mono, 66);
-$form-input-padding: .25em;
+$form-input-padding: .25em .75em;
 
 fieldset {
+  @extend .charlie;
   border: $form-input-border-width solid $form-input-border-color;
   border-radius: $form-input-border-radius;
   margin-bottom: 1em;
-  padding: 1em;
+  padding: 1em 1em 0;
 }
 
-label {}
+label {
+  font-weight: $font-weight-bold;
+}
 
 input,
 textarea {
   @include transition( all 250ms ease );
   border: $form-input-border-width solid $form-input-border-color;
-  box-sizing: border-box; // Declare explicitly, as form elements do not inherit from HTML declaration in iOS and Android
   border-radius: $form-input-border-radius;
   color: $form-input-color;
   display: inline-block;

--- a/base/_forms.scss
+++ b/base/_forms.scss
@@ -85,7 +85,6 @@ input[type="reset"],
 input[type="button"],
 button {
   @include transition(all 250ms ease);
-  border: $form-input-border-width solid $form-input-border-color;
   width: auto;
 }
 

--- a/base/_global.scss
+++ b/base/_global.scss
@@ -1,19 +1,6 @@
-// Type Sizes
-$base-type-size: 1em;
-
 //
 // Root Elements
 //
-html {
-  box-sizing: border-box;
-  font-size: $base-type-size;
-  -webkit-font-smoothing: antialiased;
-}
-
-*, *::after, *::before {
-  box-sizing: inherit;
-}
-
 html,
 body {
   height: 100%;
@@ -43,14 +30,46 @@ object {
 }
 
 //
-// Reset lists when used as navigational elements
+// Video embed containers
 //
-nav > ul, 
-nav > ol, 
-ul.menu, 
-ol.menu {
-  @include list-reset();
+// <div class="embed-container">
+// 	<iframe width="560" height="315" src="//www.youtube.com/embed/TdwT5JlH8gM?wmode=transparent" frameborder="0" allowfullscreen></iframe>
+// </div>
+//
+// @requires Modernizr to flip the /no-js class on <html> to .js
+//
+.js .embed-container {
+	@include proportional-container( 16 9 );
 
-  // More often than not, we want anchors in menus to display block
-  a { display: block; }
+	iframe,
+	object,
+	embed,
+	& > div {
+		position: absolute;
+		top: 0;
+		left: 0;
+		z-index: 1;
+		width: 100% !important;
+		height: 100% !important;
+	}
+}
+
+.no-js .embed-container {
+	padding: 1em;
+	background-color: palette(mono, 66);
+	text-align: center;
+
+	&:before {
+		@extend .charlie;
+		content: 'Sorry, embedded video players need javascript enabled.';
+		width: 100%;
+		color: palette(mono, 10);
+	}
+
+	iframe,
+	object,
+	embed,
+	& > div {
+  	@include hide();
+  }
 }

--- a/base/_global.scss
+++ b/base/_global.scss
@@ -39,37 +39,37 @@ object {
 // @requires Modernizr to flip the /no-js class on <html> to .js
 //
 .js .embed-container {
-	@include proportional-container( 16 9 );
+  @include proportional-container( 16 9 );
 
-	iframe,
-	object,
-	embed,
-	& > div {
-		position: absolute;
-		top: 0;
-		left: 0;
-		z-index: 1;
-		width: 100% !important;
-		height: 100% !important;
-	}
+  iframe,
+  object,
+  embed,
+  & > div {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
+    width: 100% !important;
+    height: 100% !important;
+  }
 }
 
 .no-js .embed-container {
-	padding: 1em;
-	background-color: palette(mono, 66);
-	text-align: center;
+  padding: 1em;
+  background-color: palette(mono, 66);
+  text-align: center;
 
-	&:before {
-		@extend .charlie;
-		content: 'Sorry, embedded video players need javascript enabled.';
-		width: 100%;
-		color: palette(mono, 10);
-	}
+  &:before {
+    @extend .charlie;
+    content: 'Sorry, embedded video players need javascript enabled.';
+    width: 100%;
+    color: palette(mono, 10);
+  }
 
-	iframe,
-	object,
-	embed,
-	& > div {
-  	@include hide();
+  iframe,
+  object,
+  embed,
+  & > div {
+    @include hide();
   }
 }

--- a/base/_reset.scss
+++ b/base/_reset.scss
@@ -1,17 +1,35 @@
 // @file reset.scss
 
+// Based on Meyer's Reset
 // http://meyerweb.com/eric/tools/css/reset/
-// v2.0 | 20110126
-// License: none (public domain)
-//
+// but also modified and simplified
+// 
+// Deprecated tags removed:
+// acronym
+// applet
+// big
+// center
+// strike
+// tt (teletype)
 
 html,
 body,
 div,
 span,
-applet,
-object,
-iframe,
+section,
+header,
+hgroup, // non-standard element, should be avoided
+nav,
+menu, // non-standard element, should be avoided
+main,
+article,
+aside,
+figure,
+figcaption,
+footer,
+time,
+audio,
+video,
 h1,
 h2,
 h3,
@@ -23,9 +41,7 @@ blockquote,
 pre,
 a,
 abbr,
-acronym,
 address,
-big,
 cite,
 code,
 del,
@@ -34,58 +50,44 @@ em,
 img,
 ins,
 kbd,
+mark,
 q,
 s,
 samp,
 small,
-strike,
 strong,
 sub,
 sup,
-tt,
 var,
 b,
 u,
 i,
-center,
 dl,
 dt,
 dd,
 ol,
 ul,
 li,
-fieldset,
 form,
+fieldset,
 label,
 legend,
 table,
 caption,
-tbody,
-tfoot,
 thead,
+tbody,
 tr,
 th,
 td,
-article,
-aside,
-canvas,
+tfoot,
 details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
 summary,
-time,
-mark,
-audio,
-video {
+canvas,
+embed,
+object,
+iframe,
+output,
+ruby {
   border: 0;
   font: inherit;
   font-size: 100%;
@@ -94,7 +96,8 @@ video {
   vertical-align: baseline;
 }
 
-// HTML5 display-role reset for older browsers
+// HTML5 display-role for Opera Mini and IE 11
+// http://caniuse.com/#feat=html5semantic
 article,
 aside,
 details,
@@ -102,31 +105,82 @@ figcaption,
 figure,
 footer,
 header,
-hgroup,
-menu,
+hgroup, // non-standard element, should be avoided
+main,
 nav,
+menu, // non-standard element, should be avoided
 section {
   display: block;
 }
 
-// We redeclare line-height in our global.scss
-//body {
-//  line-height: 1;
-//}
+// Box model declaration
+// Bourbon's Neat used to supply this declaration for us
+// Form elements do not inherit from a simple HTML declaration in iOS and Android,
+// so, declare them here explicitly
+html,
+input,
+textarea {
+  box-sizing: border-box;
+  -webkit-font-smoothing: antialiased;
+}
 
-// We fully declare UL/OL styling in typography.scss
-//ol,
-//ul {
-//  list-style: none;
-//}
+// https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/
+*,
+*::after,
+*::before {
+  box-sizing: inherit;
+}
 
-// Already declared in typography.scss
-//blockquote {
-//  quotes: none;
-//}
+// Typography resets/normalization
+// Styling here should not change from project to project
+address,
+i,
+em,
+cite,
+var {
+  font-style: italic;
+}
 
-// Already declared in typography.scss
-//table {
-//  border-collapse: collapse;
-//  border-spacing: 0;
-//}
+b,
+strong,
+th {
+  font-weight: $font-weight-bold;
+}
+
+// The <s> tag is on its way out
+// WordPress TinyMCE uses <del> instead
+del,
+s {
+  text-decoration: line-through;
+}
+
+// The <u> tag is on its way out
+// WordPress TinyMCE does not offer an underline option
+u {
+  text-decoration: underline;
+}
+
+abbr[title],
+cite,
+dfn[title] {
+  border-bottom: 1px dotted $color-link;
+  text-decoration: none;
+}
+
+abbr[title],
+dfn[title] {
+  cursor: help;
+}
+
+// Reset lists ONLY when used as navigational elements
+nav > ul, 
+nav > ol,
+ul.menu, 
+ol.menu {
+  @include list-reset();
+
+  // More often than not, anchors in menus should be block
+  a {
+    display: block;
+  }
+}

--- a/base/_typography.scss
+++ b/base/_typography.scss
@@ -1,7 +1,7 @@
 // @file typography.scss
 
 // Copy
-$paragraph: 1em;
+$base-type-size: 1em;
 $line-height: 1.75;
 
 // establishing some vertical rhythm for no type elements
@@ -14,6 +14,7 @@ input,
 select,
 textarea {
   // Size is not declared: assumed to be set by browser (default 16px)
+  // and our Reset, which declares font-size: 100%
   color: $color-text;
   font-family: $font-sans;
   font-weight: $font-weight-normal;
@@ -28,14 +29,16 @@ a {
     text-decoration: none;
   }
 
+  // Note: The text-decoration declaration is not animatable.
+  // It will not respond to the transition() that we have above.
   @include touch-hover('hover') {
     color: $color-hover;
-    text-decoration: none;
+    text-decoration: underline;
   }
 
   &[href^=tel] {
     color: inherit;
-    text-decoration: none;
+    text-decoration: dotted;
   }
 }
 
@@ -130,6 +133,14 @@ table {
   margin-bottom: $vert-line-height;
 }
 
+// Nested lists should not have margin bottom
+ol ol,
+ul ul,
+ul ol,
+ol ul {
+  margin-bottom: 0;
+}
+
 .micro { @include one-element-size(micro); }
 
 // Block level elements
@@ -168,10 +179,6 @@ blockquote {
   }
 }
 
-address {
-  font-style: italic;
-}
-
 hr {
   border: none;
   border-top: 1px solid palette(mono, 25);
@@ -183,7 +190,7 @@ hr {
 
 ul,
 ol {
-  margin-left: 3em;
+  margin-left: 1.5rem;
 }
 
 // scss-lint:disable MergeableSelector
@@ -214,7 +221,7 @@ dd {
 }
 
 dt {
-  border-bottom: 1px solid $color-borders;
+  border-bottom: 1px dotted $color-borders;
   font-weight: $font-weight-bold;
 }
 
@@ -233,7 +240,6 @@ table {
 
   th {
     border-bottom: 2px solid $table-border-color;
-    font-weight: $font-weight-bold;
     padding: $table-cell-padding;
     text-align: left;
   }
@@ -283,34 +289,11 @@ sub {
   bottom: -0.25em;
 }
 
-abbr[title],
-cite,
-dfn[title] {
-  border-bottom: 1px dotted $color-link;
-}
-
-abbr[title],
-dfn[title] {
-  cursor: help;
-}
-
 abbr[title] {
   font-size: 75%;
   font-weight: $font-weight-bold;
   letter-spacing: 0.125em;
   text-transform: uppercase;
-}
-
-b,
-strong {
-  font-weight: $font-weight-bold;
-}
-
-i,
-em,
-cite,
-var {
-  font-style: italic;
 }
 
 var {
@@ -347,8 +330,6 @@ ins {
 code,
 kbd,
 samp {
-  // scss-lint:disable DuplicateProperty
-  background: palette(mono, 10);
   background: rgba(#000, .05);
   border-radius: $default-border-radius;
   box-shadow: 0 0 .25em rgba(#000, .1) inset;
@@ -370,10 +351,6 @@ s {
 
 del {
   color: $color-error;
-}
-
-u {
-  text-decoration: underline;
 }
 
 ins {
@@ -412,14 +389,14 @@ small {
     background-color: transparent;
     border: 1px solid $color-borders;
     box-shadow: 0 0 1em rgba(#000, 0.2);
-    margin: -1em -1.25em -1px;
-    padding: 1em 1.25em 1px;
+    margin-bottom: $vert-line-height;
+    padding: 2em 1.5em 1px;
     position: relative;
   }
 
   .example::before {
     background-color: palette(brand);
-    color: #fff;
+    color: palette(mono, white);
     content: 'EXAMPLE';
     font-size: .75em;
     padding: .4em .75em .3em;
@@ -427,7 +404,7 @@ small {
       top: 0; right: 0;
     z-index: 9999;
   }
-  //.example + .examplecode { margin-top: -1.25em; }
+  .examplecode { margin-bottom: $vert-line-height; }
   .element-caption { display: block; }
 }
 


### PR DESCRIPTION
Did a few things here. Overall, the philosophy was: 

- Move things into the Reset file if they were default styles that should not change from project to project. Typically out of general.scss and out of typography.scss
- Revisit and simplify any reset rules if possible. Investigate why they are there, and keep them in if they benefit us
- Review the way out scaffold renders in a sample browser environment and make it available for anyone to review. 
- Adjust the default scaffold styles where needed. 

Overall, the reset styles that remain make sense (to me) and they serve to level the field between browsers to make it easier and quicker to pinpoint where the desired styles go wrong when they do. 

I did some research and thinking about whether or not they are needed, as described in Issue #54 . I reviewed normalize.css as well for anything useful, but did not add anything in. We design for a more modern browser set than normalize.css was built to address, so most rules would not be applicable. 