### PR TITLE
the font-family naming for FontAwesome has changed

### DIFF
--- a/abstracts/_variables.scss
+++ b/abstracts/_variables.scss
@@ -4,7 +4,7 @@
 
 // Default constants used by our mixins
 // Change below only if you require a different value
-$icon-font-family: 'font-awesome';
+$icon-font-family: 'FontAwesome';
 $min-vw: bp(small) !default;
 $max-vw: bp(x-large) !default;
 


### PR DESCRIPTION
Updating the font-family naming for FontAwesome, I'm not sure when it changed but with the latest release is using FontAwesome https://github.com/FortAwesome/Font-Awesome/tree/master/fonts

and we have this as a variable in our scaffold